### PR TITLE
Feature/160 user object

### DIFF
--- a/presentation/src/main/java/com/plub/presentation/ui/main/gathering/createGathering/preview/CreateGatheringPreviewFragment.kt
+++ b/presentation/src/main/java/com/plub/presentation/ui/main/gathering/createGathering/preview/CreateGatheringPreviewFragment.kt
@@ -4,7 +4,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import com.plub.presentation.base.BaseFragment
 import com.plub.presentation.databinding.FragmentCreateGatheringPreviewBinding
-import com.plub.presentation.ui.main.gathering.createGathering.CreateGatheringEvent
 import com.plub.presentation.ui.main.gathering.createGathering.CreateGatheringViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,7 +21,7 @@ class CreateGatheringPreviewFragment : BaseFragment<
             parentVm = parentViewModel
         }
 
-        viewModel.fetchMyInfoUrl()
+        viewModel.updateMyInfoUrl()
     }
 
     override fun onResume() {

--- a/presentation/src/main/java/com/plub/presentation/ui/main/gathering/createGathering/preview/CreateGatheringPreviewViewModel.kt
+++ b/presentation/src/main/java/com/plub/presentation/ui/main/gathering/createGathering/preview/CreateGatheringPreviewViewModel.kt
@@ -1,35 +1,17 @@
 package com.plub.presentation.ui.main.gathering.createGathering.preview
 
-import androidx.lifecycle.viewModelScope
-import com.plub.domain.model.vo.account.MyInfoResponseVo
-import com.plub.domain.usecase.FetchMyInfoUseCase
 import com.plub.presentation.base.BaseViewModel
+import com.plub.presentation.util.PlubUser
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CreateGatheringPreviewViewModel @Inject constructor(
-    private val fetchMyInfoUseCase: FetchMyInfoUseCase
-) :
-    BaseViewModel<CreateGatheringPreviewPageState>(CreateGatheringPreviewPageState()) {
+class CreateGatheringPreviewViewModel @Inject constructor()
+    : BaseViewModel<CreateGatheringPreviewPageState>(CreateGatheringPreviewPageState()) {
 
-    fun fetchMyInfoUrl() {
-        viewModelScope.launch {
-            fetchMyInfoUseCase(Unit).collect { state ->
-                inspectUiState(state, ::handleFetchMyInfoSuccess)
-            }
-        }
-    }
-
-    private fun handleFetchMyInfoSuccess(response: MyInfoResponseVo) {
-        updateMyProfileUrl(response.profileImage)
-    }
-
-    private fun updateMyProfileUrl(url: String?) {
+    fun updateMyInfoUrl() {
         updateUiState { ui ->
-            ui.copy(profileUrl = url)
+            ui.copy(profileUrl = PlubUser.info.profileImage)
         }
     }
 }

--- a/presentation/src/main/java/com/plub/presentation/ui/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/plub/presentation/ui/splash/SplashActivity.kt
@@ -2,15 +2,11 @@ package com.plub.presentation.ui.splash
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
-import android.os.Bundle
 import androidx.activity.viewModels
-import com.plub.presentation.R
 import com.plub.presentation.base.BaseActivity
 import com.plub.presentation.databinding.ActivitySplashBinding
 import com.plub.presentation.ui.PageState
 import com.plub.presentation.ui.main.MainActivity
-import com.plub.presentation.ui.main.MainEvent
 import com.plub.presentation.ui.sign.SignActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -23,7 +19,7 @@ BaseActivity<ActivitySplashBinding, PageState.Default, SplashViewModel>(Activity
     override val viewModel: SplashViewModel by viewModels()
 
     override fun initView() {
-        viewModel.reIssueTokenAfterMoveActivity()
+        viewModel.fetchMyInfo()
     }
 
     override fun initState() {

--- a/presentation/src/main/java/com/plub/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/plub/presentation/ui/splash/SplashViewModel.kt
@@ -2,38 +2,30 @@ package com.plub.presentation.ui.splash
 
 import androidx.lifecycle.viewModelScope
 import com.plub.domain.UiState
-import com.plub.domain.model.vo.jwt.PlubJwtReIssueRequestVo
-import com.plub.domain.model.vo.jwt.PlubJwtResponseVo
-import com.plub.domain.model.vo.jwt.SavePlubJwtRequestVo
-import com.plub.domain.usecase.GetPlubRefreshTokenUseCase
-import com.plub.domain.usecase.PostReIssueTokenUseCase
-import com.plub.domain.usecase.SavePlubAccessTokenAndRefreshTokenUseCase
+import com.plub.domain.model.vo.account.MyInfoResponseVo
+import com.plub.domain.usecase.FetchMyInfoUseCase
 import com.plub.presentation.base.BaseViewModel
 import com.plub.presentation.ui.PageState
+import com.plub.presentation.util.PlubUser
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val getPlubRefreshTokenUseCase: GetPlubRefreshTokenUseCase,
-    private val savePlubAccessTokenAndRefreshTokenUseCase: SavePlubAccessTokenAndRefreshTokenUseCase,
-    private val reIssueTokenUseCase: PostReIssueTokenUseCase
+    private val fetchMyInfoUseCase: FetchMyInfoUseCase
 ) : BaseViewModel<PageState.Default>(PageState.Default) {
 
-    fun reIssueTokenAfterMoveActivity() {
+    fun fetchMyInfo() {
         viewModelScope.launch {
-            val refreshToken = getPlubRefreshTokenUseCase(Unit).first()
-
             /*
              * BaseViewModel의 inspectUiState를 사용하면 로딩 프로세스가 보이기 때문에 사용하지 않음.
              */
-            reIssueTokenUseCase(PlubJwtReIssueRequestVo(refreshToken)).collect { uiState ->
+            fetchMyInfoUseCase(Unit).collect { uiState ->
                 when(uiState) {
                     is UiState.Loading -> { }
                     is UiState.Success -> {
-                        handlePostReIssueTokenSuccess(uiState.data)
+                        handleFetchMyInfoSuccess(uiState.data)
                     }
                     is UiState.Error -> {
                         emitEventFlow(SplashEvent.GoToSignUp)
@@ -43,20 +35,8 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    private fun handlePostReIssueTokenSuccess(token: PlubJwtResponseVo) {
-        if(token.isTokenValid) {
-            savePlubToken(SavePlubJwtRequestVo(token.accessToken, token.refreshToken)) {
-                emitEventFlow(SplashEvent.GoToMain)
-            }
-        }
-        else emitEventFlow(SplashEvent.GoToSignUp)
-    }
-
-    private fun savePlubToken(saveRequestVo: SavePlubJwtRequestVo, saveCallback: () -> Unit) {
-        viewModelScope.launch {
-            savePlubAccessTokenAndRefreshTokenUseCase(saveRequestVo).collect {
-                if (it) saveCallback.invoke()
-            }
-        }
+    private fun handleFetchMyInfoSuccess(data: MyInfoResponseVo) {
+        PlubUser.updateInfo(data)
+        emitEventFlow(SplashEvent.GoToMain)
     }
 }

--- a/presentation/src/main/java/com/plub/presentation/util/PlubUser.kt
+++ b/presentation/src/main/java/com/plub/presentation/util/PlubUser.kt
@@ -1,0 +1,13 @@
+package com.plub.presentation.util
+
+import com.plub.domain.model.vo.account.MyInfoResponseVo
+
+object PlubUser {
+
+    var info: MyInfoResponseVo = MyInfoResponseVo()
+        private set
+
+    fun updateInfo(info: MyInfoResponseVo) {
+        this.info = info
+    }
+}


### PR DESCRIPTION
MainActivity 진입 시, 유저 객체를 업데이트 하려 했으나 다음과 같은 문제가 있어 로직을 바꿨습니다.
1. MainActivity 진입 -> 서버에서 유저 정보를 불러온다.
2. 서버에서 유저 정보를 받아오기 전에 프로필 화면으로 이동
3. 유저 정보를 받아오지 못했기 때문에 프로필 화면에 정상적인 데이터 출력 불가

따라서 MainActivity 진입 전에 서버로부터 유저 정보를 불러오고 업데이트 하는 로직을 적용했습니다.
* 스플래시 화면
    * 내 정보 불러오기 성공
     ac, re token이 유효함, 즉 이미 로그인된 유저임 
     -> User 객체 업데이트 후 ,홈 화면 이동

    * 실패 -> 로그인 화면 이동
        * 로그인 성공 시
-> User 객체 업데이트 후 홈 화면 이동

```kotlin
object PlubUser {

    var info: MyInfoResponseVo = MyInfoResponseVo()
        private set

    fun updateInfo(info: MyInfoResponseVo) {
        this.info = info
    }
}
```
info를 통해 접근할 수 있으며, private set을 사용하여 캡슐화 했습니다.

* 사용 예시
```kotlin
updateUiState { ui ->
            ui.copy(profileUrl = PlubUser.info.profileImage)
        }
```